### PR TITLE
feat: 리프레시 토큰으로 액세스 토큰 재발급 로직 추가

### DIFF
--- a/api/external-api/src/main/java/com/mashup/betterday/controller/AuthController.java
+++ b/api/external-api/src/main/java/com/mashup/betterday/controller/AuthController.java
@@ -2,12 +2,15 @@ package com.mashup.betterday.controller;
 
 import com.mashup.betterday.AuthLoginUsecase;
 import com.mashup.betterday.OAuth2LoginUsecase;
+import com.mashup.betterday.RefreshTokenUsecase;
 import com.mashup.betterday.UserCreateUsecase;
 import com.mashup.betterday.exception.BusinessException;
 import com.mashup.betterday.exception.ErrorCode;
 import com.mashup.betterday.model.auth.AuthDto;
 import com.mashup.betterday.model.auth.AuthRequest;
 import com.mashup.betterday.model.auth.OAuth2Request;
+import com.mashup.betterday.model.auth.RefreshTokenRequest;
+import com.mashup.betterday.model.auth.TokenDto;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +26,7 @@ public class AuthController {
 
     private final AuthLoginUsecase authLoginUsecase;
     private final OAuth2LoginUsecase oAuth2LoginUsecase;
+    private final RefreshTokenUsecase refreshTokenUsecase;
 
     private final UserCreateUsecase userCreateUsecase;
 
@@ -96,9 +100,17 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    ResponseEntity<Object> refresh(
-            @RequestBody AuthRequest request
-    ) {
-        return ResponseEntity.ok(null);
+    ResponseEntity<TokenDto> refresh(@RequestBody RefreshTokenRequest request) {
+
+        RefreshTokenUsecase.TokenResponse response = refreshTokenUsecase.refresh(
+                new RefreshTokenUsecase.Request(request.getRefreshToken())
+        );
+
+        return ResponseEntity.ok(
+                new TokenDto(
+                        response.getAccessToken(),
+                        request.getRefreshToken()
+                )
+        );
     }
 }

--- a/api/external-api/src/main/java/com/mashup/betterday/model/auth/RefreshTokenRequest.java
+++ b/api/external-api/src/main/java/com/mashup/betterday/model/auth/RefreshTokenRequest.java
@@ -1,0 +1,8 @@
+package com.mashup.betterday.model.auth;
+
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequest {
+    private String refreshToken;
+}

--- a/api/external-api/src/main/java/com/mashup/betterday/model/auth/TokenDto.java
+++ b/api/external-api/src/main/java/com/mashup/betterday/model/auth/TokenDto.java
@@ -1,0 +1,11 @@
+package com.mashup.betterday.model.auth;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Data
+public class TokenDto {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/core/src/main/java/com/mashup/betterday/exception/ErrorCode.java
+++ b/core/src/main/java/com/mashup/betterday/exception/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
 
     WEEKLY_REPORT_CREATE_FAILED(400, "주간 리포트 등록에 실패했습니다."),
     WEEKLY_REPORT_NOT_FOUND(400, "주간 리포트를 조회할 수 없습니다."),
+
+    REFRESH_TOKEN_CREATE_FAILED(400, "리프레시 토큰 생성에 실패했습니다."),
     ;
 
     private final int code;

--- a/usecase/auth-usecase/src/main/java/com/mashup/betterday/AuthLoginService.java
+++ b/usecase/auth-usecase/src/main/java/com/mashup/betterday/AuthLoginService.java
@@ -1,8 +1,8 @@
 package com.mashup.betterday;
 
-import com.mashup.betterday.jwt.JwtService;
 import com.mashup.betterday.exception.BusinessException;
 import com.mashup.betterday.exception.ErrorCode;
+import com.mashup.betterday.jwt.JwtService;
 import com.mashup.betterday.user.model.User;
 import com.mashup.port.UserPort;
 import java.util.Date;
@@ -30,7 +30,11 @@ public class AuthLoginService implements AuthLoginUsecase {
                 new Date()
         );
 
-        String refreshToken = jwtService.generateRefreshToken(new Date());
+        String refreshToken = jwtService.generateRefreshToken(
+                user.getId().getValue(),
+                user.getAccount().getEmail(),
+                new Date()
+        );
 
         return new LoginResponse(
                 user,

--- a/usecase/auth-usecase/src/main/java/com/mashup/betterday/OAuth2LoginService.java
+++ b/usecase/auth-usecase/src/main/java/com/mashup/betterday/OAuth2LoginService.java
@@ -32,7 +32,11 @@ public class OAuth2LoginService implements OAuth2LoginUsecase {
                 new Date()
         );
 
-        String refreshToken = jwtService.generateRefreshToken(new Date());
+        String refreshToken = jwtService.generateRefreshToken(
+                user.getId().getValue(),
+                user.getAccount().getEmail(),
+                new Date()
+        );
 
         return new LoginResponse(
                 user,


### PR DESCRIPTION
JWT 시큐리티 필터에 액세스 키인지, 리프레시 키인지 확인하는 로직이 없음
따라서 WhiteList 요청으로 Body 로 리프레쉬 토큰을 받는 걸로 정함